### PR TITLE
SeattleColleges.github.io_7_#46_integrate-about-us-blurb

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -34,12 +34,12 @@ function About() {
           >
             <div
               style={{
-                width: "70%",
-                fontSize: "56px",
+                width: "90%",
+                fontSize: "68px",
                 fontWeight: 600,
               }}
             >
-              North Seattle Application Development
+            North Seattle Application Development 
             </div>
           </div>
           <div
@@ -59,20 +59,19 @@ function About() {
               }}
             >
               <div style={{ marginBottom: "1rem" }}>
-                <strong>Established in</strong> imperdiet dui accumsan sit amet.
-                Non pulvinar neque laoreet suspendisse interdum consectetur
-                libero id faucibus. Vehicula ipsum a arcu cursus vitae congue
-                mauris rhoncus. In nibh mauris cursus mattis molestie a.
-                Dignissim convallis aenean et tortor at risus viverra.
+                <strong>About Us:</strong><br></br><br></br> 
+                Welcome to the NSC College Application Development Program, where we empower students to create innovative and 
+                impactful solutions in the ever-evolving world of technology. Our program is dedicated to cultivating the next generation of skilled app developers, 
+                equipping them with the knowledge and hands-on experience needed to excel in the tech industry.
               </div>
-
               <div>
-                <strong>Tellus in hac habitasse</strong> platea dictumst.
-                Ullamcorper eget nulla facilisi etiam dignissim. Mauris ultrices
-                eros in cursus turpis massa. Cras adipiscing enim eu turpis
-                egestas pretium aenean pharetra magna. Est placerat in egestas
-                erat imperdiet sed euismod. Faucibus vitae aliquet nec
-                ullamcorper.
+                Through a blend of rigorous coursework, practical project development, internships and mentorships from industry experts, and engagement 
+                with real-time projects from clients, we foster a dynamic learning environment that nurtures creativity, critical thinking, and technical proficiency. 
+                Our students engage in real-world challenges, developing apps that address contemporary issues and drive technological progress.
+              </div>
+              <div style={{ marginTop: "1rem" }}>
+                At NSC, we believe in the power of education and innovation to transform lives and communities. Join us to unlock your potential, 
+                gain invaluable experience, and make a meaningful impact in the digital world. Together, we shape the future of technology.
               </div>
             </div>
           </div>


### PR DESCRIPTION
Resolves #46
Related #31, #32 

This PR integrates the about us blurb into the about us page, basically just adding the content onto the page.

There are some slight style changes for the page to accommodate the new changes. 
If they are not to peoples liking, let me know and I can make those requested changes. 

The page looks like this:
![about-us_page](https://github.com/SeattleColleges/SeattleColleges.github.io/assets/91708459/441acf74-4808-4ea8-b5e9-8438e82d99d6)