### PR TITLE
SeattleColleges.github.io_9_69_Re-add Google analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@emailjs/browser": "^4.3.3",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
+        "@fortawesome/free-brands-svg-icons": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2436,6 +2438,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.2.tgz",
+      "integrity": "sha512-zi5FNYdmKLnEc0jc0uuHH17kz/hfYTg4Uei0wMGzcoCL/4d3WM3u1VMc0iGGa31HuhV5i7ZK8ZlTCQrHqRHSGQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.2.tgz",
@@ -2446,6 +2460,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "os": "^0.1.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-ga4": "^2.1.0",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^6.23.0",
     "react-scripts": "5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,10 @@ import Contact from './pages/Contact'
 import About from './pages/About'
 import PortfolioPage from './pages/PortfolioPage'
 import StudentsPage from './pages/StudentsPage'
+import ReactGA from "react-ga4";
 
 function App() {
+  ReactGA.initialize("G-G27MNF49YJ");
   return (
     <Router>
         <Routes>


### PR DESCRIPTION

Resolves 69

Re-adds Google Analytics, which was removed when we switched to ReactJS

![image](https://github.com/SeattleColleges/SeattleColleges.github.io/assets/16846752/a715e99b-1632-4980-be9e-971702040efd)